### PR TITLE
Improvement 2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,28 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(lldb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/zig-out/bin/Cowsay",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb",
+      "preLaunchTask": "build",
+      "setupCommands": [
         {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug",
-            "program": "${workspaceFolder}/<executable file>",
-            "args": [],
-            "cwd": "${workspaceFolder}"
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "command": "zig build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "build"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ defer {
    //fail test; can't try in defer as defer is executed after we return
    if (deinit_status == .leak) @panic("TEST FAIL");
 }
-var cow = Cowsay{ .writer = stdout.any(), .allocator=gpa.allocator() };
+var cow = Cowsay.init(gpa.allocator, stdout.any());
+defer cow.deinit();
 try cow.say("Hello {s}", .{"world"});
 ```
 
@@ -135,7 +136,8 @@ Output
 var buffer = std.ArrayList(u8).init(std.heap.page_allocator);
 defer buffer.deinit();
 const w = buffer.writer().any();
-var cow = Cowsay{ .w = w };
+var cow = Cowsay.init(allocator, w);
+default cow.deinit();
 try cow.say("Hello world!", .{});
 try stdout.print("{s}", buffer.items);
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "Cowsay",
-    .version = "2.0.0",
+    .version = "3.0.0",
     .dependencies = .{
         .zg = .{
             .url = "https://codeberg.org/dude_the_builder/zg/archive/v0.13.2.tar.gz",

--- a/src/Cowsay.zig
+++ b/src/Cowsay.zig
@@ -21,25 +21,27 @@ allocator: std.mem.Allocator,
 eyes: ?[2]u8 = null,
 
 /// private variables
-cow_buffer: [1000]u8 = undefined,
-thinking: bool = false,
-max_line_length: usize = 0,
-offset: usize = 0,
-cow: []const u8 = &.{},
+cow: []const u8,
 
+pub fn init(allocator: std.mem.Allocator, writer: std.io.AnyWriter) Self {
+    return .{ .allocator = allocator, .writer = writer, .cow = default_cow };
+}
+
+pub fn deinit(self: *Self) void {
+    self.freeCowMemory();
+    self.* = undefined;
+}
 /// Print the cow saying the message. format is same as `std.fmt`
 pub fn say(self: *Self, comptime fmt: []const u8, comptime args: anytype) !void {
-    self.thinking = false;
-    try self.print(fmt, args);
+    try self.print(false, fmt, args);
 }
 
 /// Print the cow thinking the message. Same as `say` but uses `o` as the tail of the bubble.
 pub fn think(self: *Self, comptime fmt: []const u8, comptime args: anytype) !void {
-    self.thinking = true;
-    try self.print(fmt, args);
+    try self.print(true, fmt, args);
 }
 
-fn print(self: *Self, comptime fmt: []const u8, comptime args: anytype) !void {
+fn print(self: *Self, thinking: bool, comptime fmt: []const u8, comptime args: anytype) !void {
     var arena = std.heap.ArenaAllocator.init(self.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -47,48 +49,41 @@ fn print(self: *Self, comptime fmt: []const u8, comptime args: anytype) !void {
     defer buffer.deinit();
     const fmt_writer = buffer.writer();
     try std.fmt.format(fmt_writer, fmt, args);
-
-    var line_width_list = try self.findWidth(buffer.items, allocator);
-    defer line_width_list.deinit();
-
-    try self.printHLine();
-    try self.printMessage(buffer.items, line_width_list.items);
-    try self.printHLine();
-    try self.printCow();
+    const widths, const max_width = try self.findWidth(buffer.items);
+    defer widths.deinit();
+    try self.printHLine(max_width);
+    try self.printMessage(buffer.items, widths.items, max_width);
+    try self.printHLine(max_width);
+    try self.printCow(thinking, (max_width + 4) / 2);
 }
 
-fn printHLine(self: *Self) !void {
+fn printHLine(self: *Self, line_width: usize) !void {
     try self.writer.writeByte('+');
-    try self.writer.writeByteNTimes('-', self.max_line_length + 2);
+    try self.writer.writeByteNTimes('-', line_width + 2);
     try self.writer.writeAll("+\n");
 }
 
-fn printMessage(self: *Self, s: []const u8, sizes: []usize) !void {
-    //var pw = DisplayWidth{ .data = pdwd };
+fn printMessage(self: *Self, s: []const u8, widths: []const usize, max_width: usize) !void {
     var lines = std.mem.splitScalar(u8, s, '\n');
     var line_index: usize = 0;
     while (lines.next()) |line| : (line_index += 1) {
-        if (sizes[line_index] == 0) {
-            continue;
-        }
         try self.writer.writeAll("| ");
         try self.writer.writeAll(line);
-        //const line_len = pw.strWidth(line);
-        try self.writer.writeByteNTimes(' ', self.max_line_length - sizes[line_index]);
+        try self.writer.writeByteNTimes(' ', max_width - widths[line_index]);
         try self.writer.writeAll(" |\n");
     }
 }
 
-fn printCow(self: *Self) !void {
+fn printCow(self: *Self, thinking: bool, offset: usize) !void {
     if (self.cow.len == 0) {
         self.useDefaultCow();
     }
-    const bubble_tail: u8 = if (self.thinking) 'o' else '\\';
+    const bubble_tail: u8 = if (thinking) 'o' else '\\';
     var cow_lines = std.mem.splitScalar(u8, self.cow, '\n');
     var line_index: usize = 0;
     var eye_index: u8 = 0;
     while (cow_lines.next()) |line| : (line_index += 1) {
-        try self.writer.writeByteNTimes(' ', self.offset);
+        try self.writer.writeByteNTimes(' ', offset);
         if (line_index == 0) {
             try self.writer.writeByte(bubble_tail);
             try self.writer.writeAll("  ");
@@ -120,155 +115,250 @@ fn printCow(self: *Self) !void {
     }
 }
 
-fn findWidth(self: *Self, s: []const u8, allocator: std.mem.Allocator) !std.ArrayList(usize) {
-    const dwd = try DisplayWidth.DisplayWidthData.init(allocator);
+fn findWidth(self: *Self, s: []const u8) !struct { std.ArrayList(usize), usize } {
+    const dwd = try DisplayWidth.DisplayWidthData.init(self.allocator);
     defer dwd.deinit();
-    self.max_line_length = 0;
+    var widths = std.ArrayList(usize).init(self.allocator);
+    var max_width: usize = 0;
     // The `DisplayWidth` structure takes a pointer to the data.
     const dw = DisplayWidth{ .data = &dwd };
-    var line_width = std.ArrayList(usize).init(allocator);
     var lines = std.mem.splitScalar(u8, s, '\n');
     while (lines.next()) |line| {
         const line_len = dw.strWidth(line);
-        if (line_len > self.max_line_length) {
-            self.max_line_length = line_len;
+        if (line_len > max_width) {
+            max_width = line_len;
         }
-        try line_width.append(line_len);
+        try widths.append(line_len);
     }
-    self.offset = (self.max_line_length + 4) / 2;
-    return line_width;
+    return .{ widths, max_width };
 }
-// Use a ascii text cow file. file is relative to current working folder.
-// If file open or read error, use the default cow.
-pub fn useCowFile(self: *Self, filename: []const u8) void {
-    const file = std.fs.cwd().openFile(filename, .{}) catch |err| {
-        // use default
-        self.useDefaultCow();
-        std.log.err("Cow file \"{s}\": {s}. Use default cow.", .{ filename, @errorName(err) });
-        return;
-    };
+
+/// Use a ascii text cow file. file is relative to current working folder.
+pub fn useCowFile(self: *Self, filename: []const u8) !void {
+    self.freeCowMemory();
+    const file = try std.fs.cwd().openFile(filename, .{});
     defer file.close();
-    const n_read = file.readAll(&self.cow_buffer) catch |err| {
-        // use default
-        self.useDefaultCow();
-        std.log.err("Cow file \"{s}\": {s}. Use default cow.", .{ filename, @errorName(err) });
-        return;
-    };
-    self.cow = self.cow_buffer[0..n_read];
+    self.cow = try file.readToEndAlloc(self.allocator, 1000);
 }
 /// Use the default cow
 pub fn useDefaultCow(self: *Self) void {
+    self.freeCowMemory();
     self.cow = default_cow;
 }
 
-test "test findWidth" {
-    const s = "";
-    var cow = Self{ .writer = undefined, .allocator = testing.allocator };
-    const widths = try cow.findWidth(s, testing.allocator);
-    defer widths.deinit();
-
-    try testing.expectEqualSlices(usize, &[_]usize{0}, widths.items);
-    try testing.expectEqual(0, cow.max_line_length);
-    const s1 = "abc";
-    const widths1 = try cow.findWidth(s1, testing.allocator);
-    defer widths1.deinit();
-
-    try testing.expectEqualSlices(usize, &[_]usize{3}, widths1.items);
-    try testing.expectEqual(3, cow.max_line_length);
-    const s2 = "abc\n1234\n123";
-    const widths2 = try cow.findWidth(s2, testing.allocator);
-    defer widths2.deinit();
-
-    try testing.expectEqualSlices(usize, &[_]usize{ 3, 4, 3 }, widths2.items);
-    try testing.expectEqual(4, cow.max_line_length);
-    // unicode
-    const s3 = "🐮";
-    const widths3 = try cow.findWidth(s3, testing.allocator);
-    defer widths3.deinit();
-
-    try testing.expectEqualSlices(usize, &[_]usize{2}, widths3.items);
-    try testing.expectEqual(2, cow.max_line_length);
+fn freeCowMemory(self: *Self) void {
+    if (self.cow.len > 0 and self.cow.ptr != default_cow) {
+        self.allocator.free(self.cow);
+    }
 }
-test "test printHLine" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
-    const widths = try cow.findWidth("", testing.allocator);
-    defer widths.deinit();
+test findWidth {
+    const testcases = [4]struct {
+        s: []const u8,
+        want_max_width: usize,
+        want_widths: []const usize,
+    }{
+        .{ .s = "", .want_max_width = 0, .want_widths = &.{0} },
+        .{ .s = "abc", .want_max_width = 3, .want_widths = &.{3} },
+        .{ .s = "abc\n1234\n123", .want_max_width = 4, .want_widths = &.{ 3, 4, 3 } },
+        .{ .s = "🐮", .want_max_width = 2, .want_widths = &.{2} },
+    };
+    for (testcases) |testcase| {
+        const allocator = testing.allocator;
+        var cow = init(allocator, undefined);
+        defer cow.deinit();
 
-    try testing.expectEqual(0, cow.max_line_length);
-    try testing.expectEqualSlices(usize, &[_]usize{0}, widths.items);
-    try cow.printHLine();
-    try testing.expectEqualStrings("+--+\n", buffer.items);
+        const widths, const max_width = try cow.findWidth(testcase.s);
+        defer widths.deinit();
+
+        try testing.expectEqualSlices(usize, testcase.want_widths, widths.items);
+        try testing.expectEqual(testcase.want_max_width, max_width);
+    }
+}
+
+test printHLine {
+    const testcases = [2]struct { width: usize, want: []const u8 }{
+        .{ .width = 0, .want = "+--+\n" },
+        .{ .width = 3, .want = "+-----+\n" },
+    };
+    for (testcases) |testcase| {
+        const allocator = testing.allocator;
+        var buffer = std.ArrayList(u8).init(allocator);
+        defer buffer.deinit();
+        const writer = buffer.writer().any();
+        var cow = init(allocator, writer);
+        defer cow.deinit();
+        try cow.printHLine(testcase.width);
+        try testing.expectEqualStrings(testcase.want, buffer.items);
+    }
+}
+
+test printMessage {
+    const testcases = [4]struct { s: []const u8, want: []const u8 }{
+        .{ .s = "", .want = "|  |\n" },
+        .{ .s = "abc", .want = "| abc |\n" },
+        .{ .s = "abc\n1234\n123", .want = "| abc  |\n| 1234 |\n| 123  |\n" },
+        .{ .s = "🐮", .want = "| 🐮 |\n" },
+    };
+    for (testcases) |testcase| {
+        const allocator = testing.allocator;
+        var buffer = std.ArrayList(u8).init(allocator);
+        defer buffer.deinit();
+        const writer = buffer.writer().any();
+        var cow = init(allocator, writer);
+        defer cow.deinit();
+
+        const widths, const max_width = try cow.findWidth(testcase.s);
+        defer widths.deinit();
+
+        try cow.printMessage(testcase.s, widths.items, max_width);
+        try testing.expectEqualStrings(testcase.want, buffer.items);
+    }
+}
+
+test say {
+    const testcases = [4]struct { s: []const u8 = "", want: []const u8 }{
+        .{ .s = "", .want = 
+        \\+--+
+        \\|  |
+        \\+--+
+        \\  \  ^__^
+        \\   \ (oo)\_______
+        \\     (__)\       )\/\
+        \\         ||----w |
+        \\         ||     ||
+        \\
+        },
+        .{ .s = "abc", .want = 
+        \\+-----+
+        \\| abc |
+        \\+-----+
+        \\   \  ^__^
+        \\    \ (oo)\_______
+        \\      (__)\       )\/\
+        \\          ||----w |
+        \\          ||     ||
+        \\
+        },
+        .{ .s = "abc\n1234\n123", .want = 
+        \\+------+
+        \\| abc  |
+        \\| 1234 |
+        \\| 123  |
+        \\+------+
+        \\    \  ^__^
+        \\     \ (oo)\_______
+        \\       (__)\       )\/\
+        \\           ||----w |
+        \\           ||     ||
+        \\
+        },
+        .{ .s = "🐮", .want = 
+        \\+----+
+        \\| 🐮 |
+        \\+----+
+        \\   \  ^__^
+        \\    \ (oo)\_______
+        \\      (__)\       )\/\
+        \\          ||----w |
+        \\          ||     ||
+        \\
+        },
+    };
+    inline for (testcases) |testcase| {
+        const allocator = testing.allocator;
+        var buffer = std.ArrayList(u8).init(allocator);
+        defer buffer.deinit();
+        const writer = buffer.writer().any();
+        var cow = init(allocator, writer);
+        defer cow.deinit();
+        try cow.say(testcase.s, .{});
+        try testing.expectEqualStrings(testcase.want, buffer.items);
+    }
+}
+
+test think {
+    const testcases = [4]struct { s: []const u8 = "", want: []const u8 }{
+        .{ .s = "", .want = 
+        \\+--+
+        \\|  |
+        \\+--+
+        \\  o  ^__^
+        \\   o (oo)\_______
+        \\     (__)\       )\/\
+        \\         ||----w |
+        \\         ||     ||
+        \\
+        },
+        .{ .s = "abc", .want = 
+        \\+-----+
+        \\| abc |
+        \\+-----+
+        \\   o  ^__^
+        \\    o (oo)\_______
+        \\      (__)\       )\/\
+        \\          ||----w |
+        \\          ||     ||
+        \\
+        },
+        .{ .s = "abc\n1234\n123", .want = 
+        \\+------+
+        \\| abc  |
+        \\| 1234 |
+        \\| 123  |
+        \\+------+
+        \\    o  ^__^
+        \\     o (oo)\_______
+        \\       (__)\       )\/\
+        \\           ||----w |
+        \\           ||     ||
+        \\
+        },
+        .{ .s = "🐮", .want = 
+        \\+----+
+        \\| 🐮 |
+        \\+----+
+        \\   o  ^__^
+        \\    o (oo)\_______
+        \\      (__)\       )\/\
+        \\          ||----w |
+        \\          ||     ||
+        \\
+        },
+    };
+    inline for (testcases) |testcase| {
+        const allocator = testing.allocator;
+        var buffer = std.ArrayList(u8).init(allocator);
+        defer buffer.deinit();
+        const writer = buffer.writer().any();
+        var cow = init(allocator, writer);
+        defer cow.deinit();
+        try cow.think(testcase.s, .{});
+        try testing.expectEqualStrings(testcase.want, buffer.items);
+    }
+}
+
+test useCowFile {
+    const allocator = testing.allocator;
+    var buffer = std.ArrayList(u8).init(allocator);
+    defer buffer.deinit();
+    const writer = buffer.writer().any();
+    var cow = init(allocator, writer);
+    defer cow.deinit();
+
+    try cow.useCowFile("cows/cat");
+    try cow.say("Hello meow!", .{});
+    try testing.expectEqualStrings(
+        \\+-------------+
+        \\| Hello meow! |
+        \\+-------------+
+        \\       \   /\___/\
+        \\        \ (= ^.^ =)
+        \\           (") (")__/
+        \\
+    , buffer.items);
+    cow.useDefaultCow();
     buffer.clearRetainingCapacity();
-    const widths1 = try cow.findWidth("12345", testing.allocator);
-    defer widths1.deinit();
 
-    try testing.expectEqualSlices(usize, &[_]usize{5}, widths1.items);
-    try cow.printHLine();
-    try testing.expectEqualStrings("+-------+\n", buffer.items);
-}
-
-test "test printMessage 1" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
-    const s = "";
-    const widths = try cow.findWidth(s, testing.allocator);
-    defer widths.deinit();
-    try cow.printMessage(s, widths.items);
-    try testing.expectEqualStrings("", buffer.items);
-}
-
-test "test printMessage 2" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
-    const s = "abc";
-    const widths = try cow.findWidth(s, testing.allocator);
-    defer widths.deinit();
-    try cow.printMessage(s, widths.items);
-    try testing.expectEqualStrings("| abc |\n", buffer.items);
-}
-
-test "test printMessage 3" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
-    const s = "abc\n1234";
-    const widths = try cow.findWidth(s, testing.allocator);
-    defer widths.deinit();
-    try cow.printMessage(s, widths.items);
-    try testing.expectEqualStrings("| abc  |\n| 1234 |\n", buffer.items);
-}
-
-test "test printMessage 4" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
-    const s = "abc\n1234\n";
-    const widths = try cow.findWidth(s, testing.allocator);
-    defer widths.deinit();
-    try cow.printMessage(s, widths.items);
-    try testing.expectEqualStrings("| abc  |\n| 1234 |\n", buffer.items);
-}
-
-test "cow" {
-    const alloc = testing.allocator;
-    var buffer = std.ArrayList(u8).init(alloc);
-    defer buffer.deinit();
-    const w = buffer.writer().any();
-    var cow = Self{ .writer = w, .allocator = alloc };
     try cow.say("Hello world!", .{});
     try testing.expectEqualStrings(
         \\+--------------+
@@ -276,19 +366,6 @@ test "cow" {
         \\+--------------+
         \\        \  ^__^
         \\         \ (oo)\_______
-        \\           (__)\       )\/\
-        \\               ||----w |
-        \\               ||     ||
-        \\
-    , buffer.items);
-    buffer.clearRetainingCapacity();
-    try cow.think("Hello world!", .{});
-    try testing.expectEqualStrings(
-        \\+--------------+
-        \\| Hello world! |
-        \\+--------------+
-        \\        o  ^__^
-        \\         o (oo)\_______
         \\           (__)\       )\/\
         \\               ||----w |
         \\               ||     ||

--- a/src/main.zig
+++ b/src/main.zig
@@ -31,7 +31,9 @@ pub fn main() !void {
         //fail test; can't try in defer as defer is executed after we return
         if (deinit_status == .leak) @panic("TEST FAIL");
     }
-    var cow = Cowsay{ .writer = stdout.any(), .allocator = gpa.allocator() };
+    var cow = Cowsay.init(gpa.allocator(), stdout.any());
+    defer cow.deinit();
+
     cow.eyes = [_]u8{ '*', '*' };
     try cow.say("{s}", .{message});
     cow.eyes = [_]u8{ '$', '$' };
@@ -41,21 +43,20 @@ pub fn main() !void {
     try cow.say("something", .{});
     //try cs.useCowFile("bigcow");
     cow.eyes = [_]u8{ 'e', 'e' };
-    try cow.say("Hello {s}!\n", .{"world"});
+    try cow.say("Hello {s}!", .{"world"});
 
     cow.eyes = [_]u8{ 'z', 'z' };
-    try cow.say("Hello {s}!\n", .{"world"});
-    cow.useCowFile("cows/cat");
-    try cow.say("Hello {s}!\n", .{"meow"});
-    cow.useCowFile("cows/tux");
+    try cow.say("Hello {s}!", .{"world"});
+    try cow.useCowFile("cows/cat");
+    try cow.say("Hello {s}!", .{"meow"});
+    try cow.useCowFile("cows/tux");
     cow.eyes = [_]u8{ 'o', 'o' };
-    try cow.say("Hello {s}!\n", .{"Linux"});
+    try cow.say("Hello {s}!", .{"Linux"});
     // use default cow
-    cow.useCowFile("");
-    try cow.think("Hmm... Hello ... world ...\n", .{});
     cow.useDefaultCow();
+    try cow.think("Hmm... Hello ... world ...", .{});
     try cow.say("Hello wörld! 你好！", .{});
-    cow.useCowFile("cows/cow-utf8");
+    try cow.useCowFile("cows/cow-utf8");
     try cow.say("Hello world! 🐷", .{});
 }
 


### PR DESCRIPTION
Thanks to @mochalins improvements round 2 (#5)

- add `init` and `deinit`
- dynamically alloc and free `cow`
- move member variables to local variables
- maximize usage of const
- testdoc
- scoped sub-testcase

